### PR TITLE
fixes bug in uv_tex

### DIFF
--- a/utils/uv.py
+++ b/utils/uv.py
@@ -77,7 +77,7 @@ def bilinear_interpolate(img, x, y):
 
 
 def uv_tex(img, ver_lst, tri, uv_h=256, uv_w=256, uv_c=3, show_flag=False, wfp=None):
-    uv_coords = process_uv(g_uv_coords, uv_h=uv_h, uv_w=uv_w)
+    uv_coords = process_uv(g_uv_coords.copy(), uv_h=uv_h, uv_w=uv_w)
 
     res_lst = []
     for ver_ in ver_lst:


### PR DESCRIPTION
When uv_tex function is called multiple times it changes the internal state of the module (as far as my testing goes this is not fixable without killing the python process).

Replicate:

```python
import cv2
import yaml

from FaceBoxes import FaceBoxes
from TDDFA import TDDFA
from utils.uv import uv_tex

import matplotlib.pyplot as plt
from skimage import io

# load config
cfg = yaml.load(open('configs/mb1_120x120.yml'), Loader=yaml.SafeLoader)

face_boxes = FaceBoxes()
tddfa = TDDFA(gpu_mode=False, **cfg)

img_urls = ['https://raw.githubusercontent.com/cleardusk/3DDFA_V2/master/examples/inputs/emma.jpg',
            'https://raw.githubusercontent.com/cleardusk/3DDFA_V2/master/examples/inputs/emma.jpg']

for img_url in img_urls:
  from utils.uv import uv_tex
  img = io.imread(img_url)
  plt.imshow(img)

  img = img[..., ::-1]  # RGB -> BGR

  # face detection
  boxes = face_boxes(img)
  print(f'Detect {len(boxes)} faces')
  print(boxes)

  # regress 3DMM params
  param_lst, roi_box_lst = tddfa(img, boxes)
  ver_lst = tddfa.recon_vers(param_lst, roi_box_lst, dense_flag=True)
  print(ver_lst)
  uv_tex(img, ver_lst, tddfa.tri, show_flag=True)
```