### PR TITLE
Update cpu_nms.pyx

### DIFF
--- a/FaceBoxes/utils/nms/cpu_nms.pyx
+++ b/FaceBoxes/utils/nms/cpu_nms.pyx
@@ -26,7 +26,7 @@ def cpu_nms(np.ndarray[np.float32_t, ndim=2] dets, np.float thresh):
 
     cdef int ndets = dets.shape[0]
     cdef np.ndarray[np.int_t, ndim=1] suppressed = \
-            np.zeros((ndets), dtype=np.int)
+            np.zeros((ndets), dtype=np.int_)
 
     # nominal indices
     cdef int _i, _j


### PR DESCRIPTION
numpy.int was deprecated in NumPy 1.20 and was removed in NumPy 1.24.

You can change it to numpy.int_, or just int.